### PR TITLE
Smoother animation

### DIFF
--- a/src/edu/macalester/graphics/AnimationTimer.java
+++ b/src/edu/macalester/graphics/AnimationTimer.java
@@ -1,0 +1,39 @@
+package edu.macalester.graphics;
+
+import java.util.function.DoubleConsumer;
+
+/**
+ * Simple timer that provides a more stable frame rate than Swing's built-in timer,
+ * and passes a dt to its callback.
+ */
+class AnimationTimer implements Runnable {
+    private final long targetInterval;
+    private final DoubleConsumer callback;
+
+    AnimationTimer(long targetInterval, DoubleConsumer callback) {
+        this.targetInterval = targetInterval;
+        this.callback = callback;
+        
+        Thread thread = new Thread(this, "animation timer");
+        thread.setPriority((Thread.NORM_PRIORITY + Thread.MAX_PRIORITY) / 2);
+        thread.start();
+    }
+
+    @Override
+    public void run() {
+        long lastUpdate = System.currentTimeMillis() - targetInterval;
+        while (true) {
+            long curTime = System.currentTimeMillis();
+
+            callback.accept((curTime - lastUpdate) / 1000.0);
+
+            lastUpdate = curTime;
+            try {
+                Thread.sleep(Math.max(0, lastUpdate + targetInterval - System.currentTimeMillis()));
+            } catch (InterruptedException e) {
+                System.err.println(getClass().getSimpleName() + " interrupted");
+                return;
+            }
+        }
+    }
+}

--- a/src/edu/macalester/graphics/FrameRateReporter.java
+++ b/src/edu/macalester/graphics/FrameRateReporter.java
@@ -14,7 +14,12 @@ public class FrameRateReporter {
         framesSinceLastReport++;
         long curTime = System.currentTimeMillis();
         if(curTime - timeOfLastReport > 200) {
-            System.out.printf("%2.1f fps\n", (double) framesSinceLastReport / (curTime - timeOfLastReport) * 1000);
+            double rate = (double) framesSinceLastReport / (curTime - timeOfLastReport) * 1000;
+            System.out.printf("%2.1f fps ", rate);
+            for (int n = 0; n < Math.round(rate); n++) {
+                System.out.print("🟦");
+            }
+            System.out.println();
             framesSinceLastReport = 0;
             timeOfLastReport = curTime;
         }


### PR DESCRIPTION
Ditching Swing’s timer in favor of a custom timer class that delivers a stabler, smoother frame rate.

Adds a second variant of `canvas.animate()` that accepts a callback with a `dt` parameter, so that animations can compensate for actual frame rate to create smoother apparent motion. (This was really noticeable with Critters on a large screen!)