### PR TITLE
added rendering hints to help with pixel art scaling

### DIFF
--- a/src/edu/macalester/graphics/GraphicsObject.java
+++ b/src/edu/macalester/graphics/GraphicsObject.java
@@ -1,6 +1,7 @@
 package edu.macalester.graphics;
 
 import java.awt.Graphics2D;
+import java.awt.RenderingHints;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
@@ -24,9 +25,11 @@ public abstract class GraphicsObject {
     private double rotation = 0;
     private Point scale = Point.ONE_ONE;
     private Point anchor;
+    private Object interpolationMode = RenderingHints.VALUE_INTERPOLATION_BILINEAR;
     private final AffineTransform transform = new AffineTransform(), inverseTransform = new AffineTransform();
 
     final void draw(Graphics2D gc) {
+        gc.setRenderingHint(RenderingHints.KEY_INTERPOLATION, interpolationMode);
         AffineTransform oldTransform = gc.getTransform();
         gc.transform(transform);
         drawInLocalCoordinates(gc);
@@ -240,6 +243,27 @@ public abstract class GraphicsObject {
      */
     public final void setScale(double scale) {
         setScale(scale, scale);
+    }
+
+
+    /**
+     * Sets the interpolation mode used when rendering this object. Has no effect unless the
+     * object is scaled or rotated. "Bilinear" is the default. "Nearest Neighbor" looks best 
+     * for pixel art. "Bicubic" may look better than bilinear in certain situations.
+     * @param mode "Nearest Neighbor", "Bilinear", or "Bicubic". Case-insensitive.
+     */
+    public final void setInterpolationMode(String mode) {
+        switch (mode.toLowerCase()) {
+            case "nearest neighbor":
+                interpolationMode = RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR;
+                break;
+            case "bicubic":
+                interpolationMode = RenderingHints.VALUE_INTERPOLATION_BICUBIC;
+                break;
+            default:
+                interpolationMode = RenderingHints.VALUE_INTERPOLATION_BILINEAR;
+                break;
+        }
     }
 
     /**


### PR DESCRIPTION
Nearest neighbor interpolation is about 10x faster and looks much better than the default bilinear interpolation when scaling up pixel art, so I added a method on GraphicsObjects that allows you to set the mode. RenderingHints also allows for bicubic interpolation so I added that too, but personally I can't tell the difference and its about 10x slower than bilinear interpolation so I'd be okay with not including it, because it could end up being more trouble than its worth if someone abuses it. Then this method could accept a boolean instead of a string. But all I can say is my group would've really appreciated having nearest interpolation for our 127 final project because it felt unnecessarily challenging to work around, and I think it would be cool to introduce students to tradeoffs in rendering because woah graphics how do computers count so fast