### PR TITLE
CI change: updated upload-artifacts to v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Upload image comparisons (on failure only)
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: imageComparisons
           path: test/imageComparisons/


### PR DESCRIPTION
CI now fails because v3 is deprecated. More about v4:

https://github.blog/news-insights/product-news/get-started-with-v4-of-github-actions-artifacts/